### PR TITLE
Add constrain to data keys option addressing #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,20 @@ MongoClient.connect(dbUrl, function (err, dbConnection) {
 
 ## API
 
-### obfusticate(schemas, dbConnection, cb)
+### obfusticate(schemas, dbConnection, options, cb)
 
 Obfusticates all data in the collections denoted by the keys of the `schemas`
 object (like the example shown above). `dbConnection` is an instance of
 `MongoClient`.
+
+`options` is an optional parameter and can be omitted. If omitted the default options as described below will be used.
+
+#### options
+
+##### constrainToDataKeys
+**Default:** `false`
+
+If set to `true` then no keys not already on the items will be obfusticated. If `false` then all the keys provided in the `schemas` object will be obfusticated and added to the items in the collection even if they did not previously exist. This only applies for top-level keys and is not enforced for any nested keys even if set to `true`.
 
 ## Credits
 [Ben Parnell](https://github.com/benjaminparnell)

--- a/README.md
+++ b/README.md
@@ -38,14 +38,8 @@ Obfusticates all data in the collections denoted by the keys of the `schemas`
 object (like the example shown above). `dbConnection` is an instance of
 `MongoClient`.
 
-`options` is an optional parameter and can be omitted. If omitted the default options as described below will be used.
-
-#### options
-
-##### constrainToDataKeys
-**Default:** `false`
-
-If set to `true` then no keys not already on the items will be obfusticated. If `false` then all the keys provided in the `schemas` object will be obfusticated and added to the items in the collection even if they did not previously exist. This only applies for top-level keys and is not enforced for any nested keys even if set to `true`.
+Any top-level keys that are on the schema but are not already on the items in 
+the collection will be ignored.
 
 ## Credits
 [Ben Parnell](https://github.com/benjaminparnell)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ MongoClient.connect(dbUrl, function (err, dbConnection) {
 
 ## API
 
-### obfusticate(schemas, dbConnection, options, cb)
+### obfusticate(schemas, dbConnection, cb)
 
 Obfusticates all data in the collections denoted by the keys of the `schemas`
 object (like the example shown above). `dbConnection` is an instance of

--- a/index.js
+++ b/index.js
@@ -5,12 +5,7 @@ var async = require('async')
   , DocumentObfusticateStream = require('./lib/document-obfusticate-stream')
   , EventEmitter = require('events').EventEmitter
 
-function obfusticate (schemas, db, options, callback) {
-  if (typeof options === 'function') {
-    callback = options
-    options = {}
-  }
-
+function obfusticate (schemas, db, callback) {
   var collections = Object.keys(schemas)
     , emitter = new EventEmitter()
 
@@ -18,7 +13,7 @@ function obfusticate (schemas, db, options, callback) {
 
   async.series([
     countRecords.bind(null, collections, db, emitter)
-  , run.bind(null, schemas, db, emitter, collections, options)
+  , run.bind(null, schemas, db, emitter, collections)
   ], function (err, res) {
     if (err) {
       emitter.emit('error', err)
@@ -46,12 +41,11 @@ function countRecords (collections, db, emitter, callback) {
   })
 }
 
-function run (schemas, db, emitter, collections, options, callback) {
+function run (schemas, db, emitter, collections, callback) {
   async.reduce(collections, {}, function (counts, collection, cb) {
     var updateStream = new MongoStream({ connection: db, collection: collection })
       , findStream = db.collection(collection).find({}).stream()
-      , documentObfusticationStream =
-          new DocumentObfusticateStream(schemas[collection], options.constrainToDataKeys)
+      , documentObfusticationStream = new DocumentObfusticateStream(schemas[collection])
 
     counts[collection] = 0
 

--- a/lib/document-obfusticate-stream.js
+++ b/lib/document-obfusticate-stream.js
@@ -5,11 +5,10 @@ var TransformStream = require('stream').Transform
   , extend = require('lodash.assign')
   , pick = require('lodash.pick')
 
-function DocumentObfusticateStream (schema, constrainToDataKeys) {
+function DocumentObfusticateStream (schema) {
   TransformStream.call(this)
   this._writableState.objectMode = true
   this._readableState.objectMode = true
-  this.constrainToDataKeys = constrainToDataKeys
   this.schema = schema
 }
 
@@ -17,7 +16,7 @@ DocumentObfusticateStream.prototype = Object.create(TransformStream.prototype)
 
 DocumentObfusticateStream.prototype._transform = function (chunk, encoding, callback) {
   var itemKeys = Object.keys(chunk)
-    , schema = !this.constrainToDataKeys ? this.schema : pick(this.schema, itemKeys)
+    , schema = pick(this.schema, itemKeys)
 
   chunk = extend({}, chunk, generateFakeData(schema))
   this.push(chunk)

--- a/lib/document-obfusticate-stream.js
+++ b/lib/document-obfusticate-stream.js
@@ -3,18 +3,23 @@ module.exports = DocumentObfusticateStream
 var TransformStream = require('stream').Transform
   , generateFakeData = require('./fake-data-generator')
   , extend = require('lodash.assign')
+  , pick = require('lodash.pick')
 
-function DocumentObfusticateStream (schema) {
+function DocumentObfusticateStream (schema, constrainToDataKeys) {
   TransformStream.call(this)
   this._writableState.objectMode = true
   this._readableState.objectMode = true
+  this.constrainToDataKeys = constrainToDataKeys
   this.schema = schema
 }
 
 DocumentObfusticateStream.prototype = Object.create(TransformStream.prototype)
 
 DocumentObfusticateStream.prototype._transform = function (chunk, encoding, callback) {
-  chunk = extend({}, chunk, generateFakeData(this.schema))
+  var itemKeys = Object.keys(chunk)
+    , schema = !this.constrainToDataKeys ? this.schema : pick(this.schema, itemKeys)
+
+  chunk = extend({}, chunk, generateFakeData(schema))
   this.push(chunk)
   callback()
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "async": "^2.0.1",
     "faker": "^3.1.0",
     "find-and-modify-stream": "^1.0.1",
-    "lodash.assign": "^4.1.0"
+    "lodash.assign": "^4.1.0",
+    "lodash.pick": "^4.4.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.12",

--- a/test/document-obfusticate-stream.test.js
+++ b/test/document-obfusticate-stream.test.js
@@ -50,4 +50,73 @@ describe('#DocumentObfusticateStream', function () {
     stream.write({})
     stream.write({})
   })
+
+  describe('constrainToDataKeys', function () {
+    it('should add provided schema fields to objects if not set', function (done) {
+      var schema = {
+            firstName: 'name.firstName'
+          , phone: 'phone.phoneNumber'
+          , bitcoinWallet: 'finance.bitcoinAddress'
+          }
+        , originalData = { _id: 1, firstName: 'name' }
+        , stream = new DocumentObfusticateStream(schema)
+
+      stream
+        .pipe(streamAssert.first(function (data) {
+          assert.equal(Object.keys(data).length, 4, 'Fields not added to the data')
+          Object.keys(schema).forEach(function (key) {
+            assert.equal(typeof data[key], 'string')
+          })
+        }))
+        .pipe(streamAssert.end(done))
+        .end()
+
+      stream.write(originalData)
+    })
+
+    it('should add provided schema fields to objects if false', function (done) {
+      var schema = {
+            firstName: 'name.firstName'
+          , phone: 'phone.phoneNumber'
+          , bitcoinWallet: 'finance.bitcoinAddress'
+          }
+        , originalData = { _id: 1, firstName: 'name' }
+        , stream = new DocumentObfusticateStream(schema, false)
+
+      stream
+        .pipe(streamAssert.first(function (data) {
+          assert.equal(Object.keys(data).length, 4, 'Fields not added to the data')
+          Object.keys(schema).forEach(function (key) {
+            assert.equal(typeof data[key], 'string')
+          })
+        }))
+        .pipe(streamAssert.end(done))
+        .end()
+
+      stream.write(originalData)
+    })
+
+    it('should not add provided schema fields to objects if true', function (done) {
+      var schema = {
+            firstName: 'name.firstName'
+          , phone: 'phone.phoneNumber'
+          , bitcoinWallet: 'finance.bitcoinAddress'
+          }
+        , originalData = { _id: 1, firstName: 'name' }
+        , stream = new DocumentObfusticateStream(schema, true)
+
+      stream
+        .pipe(streamAssert.first(function (data) {
+          assert.equal(Object.keys(data).length, 2, 'Fields added to the data')
+          Object.keys(originalData).forEach(function (key) {
+            assert.equal(typeof data[key], typeof originalData[key])
+            if (key !== '_id') assert.notEqual(originalData[key], data[key])
+          })
+        }))
+        .pipe(streamAssert.end(done))
+        .end()
+
+      stream.write(originalData)
+    })
+  })
 })

--- a/test/document-obfusticate-stream.test.js
+++ b/test/document-obfusticate-stream.test.js
@@ -8,7 +8,7 @@ describe('#DocumentObfusticateStream', function () {
     assert.ok(new DocumentObfusticateStream({}) instanceof stream.Transform)
   })
 
-  it('should add some data to an object piped to it', function (done) {
+  it('should fake some data to an object piped to it', function (done) {
     var schema = {
           firstName: 'name.firstName'
         , phone: 'phone.phoneNumber'
@@ -25,7 +25,7 @@ describe('#DocumentObfusticateStream', function () {
       .pipe(streamAssert.end(done))
       .end()
 
-    stream.write({ _id: 1 })
+    stream.write(schema)
   })
 
   it('should not add the same data to every object piped to it', function (done) {
@@ -47,76 +47,30 @@ describe('#DocumentObfusticateStream', function () {
       .pipe(streamAssert.end(done))
       .end()
 
-    stream.write({})
-    stream.write({})
+    stream.write(schema)
+    stream.write(schema)
   })
 
-  describe('constrainToDataKeys', function () {
-    it('should add provided schema fields to objects if not set', function (done) {
-      var schema = {
-            firstName: 'name.firstName'
-          , phone: 'phone.phoneNumber'
-          , bitcoinWallet: 'finance.bitcoinAddress'
-          }
-        , originalData = { _id: 1, firstName: 'name' }
-        , stream = new DocumentObfusticateStream(schema)
+  it('should not add provided schema fields to objects', function (done) {
+    var schema = {
+          firstName: 'name.firstName'
+        , phone: 'phone.phoneNumber'
+        , bitcoinWallet: 'finance.bitcoinAddress'
+        }
+      , originalData = { _id: 1, firstName: 'name' }
+      , stream = new DocumentObfusticateStream(schema, true)
 
-      stream
-        .pipe(streamAssert.first(function (data) {
-          assert.equal(Object.keys(data).length, 4, 'Fields not added to the data')
-          Object.keys(schema).forEach(function (key) {
-            assert.equal(typeof data[key], 'string')
-          })
-        }))
-        .pipe(streamAssert.end(done))
-        .end()
+    stream
+      .pipe(streamAssert.first(function (data) {
+        assert.equal(Object.keys(data).length, 2, 'Fields added to the data')
+        Object.keys(originalData).forEach(function (key) {
+          assert.equal(typeof data[key], typeof originalData[key])
+          if (key !== '_id') assert.notEqual(originalData[key], data[key])
+        })
+      }))
+      .pipe(streamAssert.end(done))
+      .end()
 
-      stream.write(originalData)
-    })
-
-    it('should add provided schema fields to objects if false', function (done) {
-      var schema = {
-            firstName: 'name.firstName'
-          , phone: 'phone.phoneNumber'
-          , bitcoinWallet: 'finance.bitcoinAddress'
-          }
-        , originalData = { _id: 1, firstName: 'name' }
-        , stream = new DocumentObfusticateStream(schema, false)
-
-      stream
-        .pipe(streamAssert.first(function (data) {
-          assert.equal(Object.keys(data).length, 4, 'Fields not added to the data')
-          Object.keys(schema).forEach(function (key) {
-            assert.equal(typeof data[key], 'string')
-          })
-        }))
-        .pipe(streamAssert.end(done))
-        .end()
-
-      stream.write(originalData)
-    })
-
-    it('should not add provided schema fields to objects if true', function (done) {
-      var schema = {
-            firstName: 'name.firstName'
-          , phone: 'phone.phoneNumber'
-          , bitcoinWallet: 'finance.bitcoinAddress'
-          }
-        , originalData = { _id: 1, firstName: 'name' }
-        , stream = new DocumentObfusticateStream(schema, true)
-
-      stream
-        .pipe(streamAssert.first(function (data) {
-          assert.equal(Object.keys(data).length, 2, 'Fields added to the data')
-          Object.keys(originalData).forEach(function (key) {
-            assert.equal(typeof data[key], typeof originalData[key])
-            if (key !== '_id') assert.notEqual(originalData[key], data[key])
-          })
-        }))
-        .pipe(streamAssert.end(done))
-        .end()
-
-      stream.write(originalData)
-    })
+    stream.write(originalData)
   })
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -168,111 +168,36 @@ describe('#obfusticate', function () {
     })
   })
 
-  describe('options', function () {
-    var extendedSchemas = {
-      'user': {
-        'firstName': function () {
-          return 'Ben'
-        }
-      , 'lastName': function () {
-          return 'Parnell'
-        }
-      , 'occupation': function () {
-          return 'Wizard'
-        }
-      }
-    , 'questionResponse': {
-        'color': function () {
-          return 'yellow'
-        }
-      , 'shape': function () {
-          return 'square'
-        }
-      , 'city': function () {
-          return 'Nottingham'
-        }
-      }
-    }
-
-    describe('constrainToDataKeys', function () {
-      it('should obfusticate schema data in all collections passed to it if not set', function (done) {
-        var questionResponseFixtures = createQuestionResponseFixtures(30)
-          , userFixtures = createUserFixtures(10)
-
-        async.parallel([
-          userCollection.insertMany.bind(userCollection, userFixtures)
-        , questionResposeCollection.insertMany.bind(questionResposeCollection, questionResponseFixtures)
-        ], function (err) {
-          if (err) return done(err)
-          obfusticate(extendedSchemas, db, function (err) {
-            if (err) return done(err)
-            async.each(Object.keys(extendedSchemas), function (collectionName, eachCb) {
-              var collection = db.collection(collectionName)
-              collection.find({}).toArray(function (err, docs) {
-                if (err) return done(err)
-                docs.forEach(function (doc) {
-                  var docWithFakeData = extend({}, generateFakeData(extendedSchemas[collectionName]), doc)
-                  assert.deepEqual(doc, docWithFakeData)
-                })
-                eachCb()
+  it('should obfusticate collection data only in all collections passed to it', function (done) {
+    var questionResponseFixtures = createQuestionResponseFixtures(30)
+      , userFixtures = createUserFixtures(10)
+      , extendedSchemas =
+          { user: extend({}, schemas.user
+            , { occupation: function () { return 'Wizard' }
               })
-            }, done)
-          })
-        })
-      })
-
-      it('should obfusticate schema data in all collections passed to it if false', function (done) {
-        var questionResponseFixtures = createQuestionResponseFixtures(30)
-          , userFixtures = createUserFixtures(10)
-          , options = { constrainToDataKeys: false }
-
-        async.parallel([
-          userCollection.insertMany.bind(userCollection, userFixtures)
-        , questionResposeCollection.insertMany.bind(questionResposeCollection, questionResponseFixtures)
-        ], function (err) {
-          if (err) return done(err)
-          obfusticate(extendedSchemas, db, options, function (err) {
-            if (err) return done(err)
-            async.each(Object.keys(extendedSchemas), function (collectionName, eachCb) {
-              var collection = db.collection(collectionName)
-              collection.find({}).toArray(function (err, docs) {
-                if (err) return done(err)
-                docs.forEach(function (doc) {
-                  var docWithFakeData = extend({}, generateFakeData(extendedSchemas[collectionName]), doc)
-                  assert.deepEqual(doc, docWithFakeData)
-                })
-                eachCb()
+          , questionResponse: extend({}, schemas.questionResponse
+            , { shape: function () { return 'square' }
               })
-            }, done)
-          })
-        })
-      })
+          }
 
-      it('should obfusticate collection data only in all collections passed to it if true', function (done) {
-        var questionResponseFixtures = createQuestionResponseFixtures(30)
-          , userFixtures = createUserFixtures(10)
-          , options = { constrainToDataKeys: true }
-
-        async.parallel([
-          userCollection.insertMany.bind(userCollection, userFixtures)
-        , questionResposeCollection.insertMany.bind(questionResposeCollection, questionResponseFixtures)
-        ], function (err) {
-          if (err) return done(err)
-          obfusticate(extendedSchemas, db, options, function (err) {
+    async.parallel([
+      userCollection.insertMany.bind(userCollection, userFixtures)
+    , questionResposeCollection.insertMany.bind(questionResposeCollection, questionResponseFixtures)
+    ], function (err) {
+      if (err) return done(err)
+      obfusticate(extendedSchemas, db, function (err) {
+        if (err) return done(err)
+        async.each(Object.keys(extendedSchemas), function (collectionName, eachCb) {
+          var collection = db.collection(collectionName)
+          collection.find({}).toArray(function (err, docs) {
             if (err) return done(err)
-            async.each(Object.keys(extendedSchemas), function (collectionName, eachCb) {
-              var collection = db.collection(collectionName)
-              collection.find({}).toArray(function (err, docs) {
-                if (err) return done(err)
-                docs.forEach(function (doc) {
-                  var docWithFakeData = extend({}, generateFakeData(schemas[collectionName]), doc)
-                  assert.deepEqual(doc, docWithFakeData)
-                })
-                eachCb()
-              })
-            }, done)
+            docs.forEach(function (doc) {
+              var docWithFakeData = extend({}, generateFakeData(schemas[collectionName]), doc)
+              assert.deepEqual(doc, docWithFakeData)
+            })
+            eachCb()
           })
-        })
+        }, done)
       })
     })
   })


### PR DESCRIPTION
➕ Adds `lodash.pick` dependency.
✅  Tests updated for index.
✅  Tests updated for document stream.
✅  Addresses an issue, namely #6.
📝  Readme updated with information.
❓  Not sure that that readme reads right to me.
❓   Issue that this only works on top-level keys, raising the question of whether it's even worth it 🎉 .
❓  Made it kind of messy by adding an options object, though this could be used for other things like whether to enable warnings for #5 maybe.

:tada: :boom:
